### PR TITLE
Allow for concurrent requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 exclude = [".gitignore", ".github/*"]
 
 [dependencies]
-enr = { version = "0.9", features = ["k256", "ed25519"] }
+enr = { version = "0.10", features = ["k256", "ed25519"] }
 tokio = { version = "1", features = ["net", "sync", "macros", "rt"] }
 libp2p = { version = "0.52", features = ["ed25519", "secp256k1"], optional = true }
 zeroize = { version = "1", features = ["zeroize_derive"] }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A simple example of creating this service is as follows:
 
    // construct a local ENR
    let enr_key = CombinedKey::generate_secp256k1();
-   let enr = enr::EnrBuilder::new("v4").build(&enr_key).unwrap();
+   let enr = enr::Enr::empty(&enr_key).unwrap();
 
    // build the tokio executor
    let mut runtime = tokio::runtime::Builder::new_multi_thread()

--- a/examples/custom_executor.rs
+++ b/examples/custom_executor.rs
@@ -29,7 +29,7 @@ fn main() {
 
     let enr_key = CombinedKey::generate_secp256k1();
     // construct a local ENR
-    let enr = enr::EnrBuilder::new("v4").build(&enr_key).unwrap();
+    let enr = enr::Enr::empty(&enr_key).unwrap();
 
     // build the tokio executor
     let runtime = tokio::runtime::Builder::new_multi_thread()

--- a/examples/find_nodes.rs
+++ b/examples/find_nodes.rs
@@ -90,7 +90,7 @@ async fn main() {
     };
 
     let enr = {
-        let mut builder = enr::EnrBuilder::new("v4");
+        let mut builder = enr::Enr::builder();
         if let Some(ip4) = args.enr_ip4 {
             // if the given address is the UNSPECIFIED address we want to advertise localhost
             if ip4.is_unspecified() {

--- a/examples/request_enr.rs
+++ b/examples/request_enr.rs
@@ -43,7 +43,7 @@ async fn main() {
     // generate a new enr key
     let enr_key = CombinedKey::generate_secp256k1();
     // construct a local ENR
-    let enr = enr::EnrBuilder::new("v4").build(&enr_key).unwrap();
+    let enr = enr::Enr::empty(&enr_key).unwrap();
 
     // default discv5 configuration
     let config = ConfigBuilder::new(listen_config).build();

--- a/examples/simple_server.rs
+++ b/examples/simple_server.rs
@@ -46,7 +46,7 @@ async fn main() {
 
     // construct a local ENR
     let enr = {
-        let mut builder = enr::EnrBuilder::new("v4");
+        let mut builder = enr::Enr::builder();
         // if an IP was specified, use it
         if let Some(external_address) = address {
             builder.ip4(external_address);

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -49,7 +49,7 @@ lazy_static! {
         RwLock::new(crate::PermitBanList::default());
 }
 
-mod test;
+pub(crate) mod test;
 
 /// Events that can be produced by the `Discv5` event stream.
 #[derive(Debug)]

--- a/src/discv5/test.rs
+++ b/src/discv5/test.rs
@@ -124,7 +124,7 @@ async fn build_nodes_from_keypairs_dual_stack(
 }
 
 /// Generate `n` deterministic keypairs from a given seed.
-fn generate_deterministic_keypair(n: usize, seed: u64) -> Vec<CombinedKey> {
+pub(crate) fn generate_deterministic_keypair(n: usize, seed: u64) -> Vec<CombinedKey> {
     let mut keypairs = Vec::new();
     for i in 0..n {
         let sk = {

--- a/src/handler/active_requests.rs
+++ b/src/handler/active_requests.rs
@@ -76,9 +76,12 @@ impl ActiveRequests {
         node_address: &NodeAddress,
         id: &RequestId,
     ) -> Option<RequestCall> {
-        match self.active_requests_mapping.entry(node_address.to_owned()) {
+        match self.active_requests_mapping.entry(node_address.clone()) {
             Entry::Vacant(_) => None,
             Entry::Occupied(mut requests) => {
+                if requests.get().is_empty() {
+                    return None;
+                }
                 let index = requests.get().iter().position(|req| {
                     let req_id: RequestId = req.id().into();
                     &req_id == id
@@ -125,6 +128,9 @@ impl Stream for ActiveRequests {
                 match self.active_requests_mapping.entry(node_address.clone()) {
                     Entry::Vacant(_) => Poll::Ready(None),
                     Entry::Occupied(mut requests) => {
+                        if requests.get().is_empty() {
+                            return Poll::Ready(None);
+                        }
                         match requests
                             .get()
                             .iter()

--- a/src/handler/active_requests.rs
+++ b/src/handler/active_requests.rs
@@ -32,6 +32,10 @@ impl ActiveRequests {
             .insert(nonce, node_address);
     }
 
+    pub fn get(&self, node_address: &NodeAddress) -> Option<&Vec<RequestCall>> {
+        self.active_requests_mapping.get(node_address)
+    }
+
     /// Remove a single request identified by its nonce.
     pub fn remove_by_nonce(&mut self, nonce: &MessageNonce) -> Option<(NodeAddress, RequestCall)> {
         let node_address = self.active_requests_nonce_mapping.remove(nonce)?;

--- a/src/handler/active_requests.rs
+++ b/src/handler/active_requests.rs
@@ -87,13 +87,7 @@ impl ActiveRequests {
             .get(node_address)?
             .iter()
             .filter(|req| req.packet().message_nonce() != except)
-            .map(|req| {
-                match req.id() {
-                    HandlerReqId::Internal(id) => id,
-                    HandlerReqId::External(id) => id,
-                }
-                .clone()
-            })
+            .map(|req| req.id().into())
             .collect::<Vec<_>>();
 
         let mut requests = vec![];

--- a/src/handler/active_requests.rs
+++ b/src/handler/active_requests.rs
@@ -26,7 +26,7 @@ impl ActiveRequests {
         let nonce = *request_call.packet().message_nonce();
         self.active_requests_mapping
             .entry(node_address.clone())
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(request_call);
         self.active_requests_nonce_mapping
             .insert(nonce, node_address);
@@ -43,10 +43,8 @@ impl ActiveRequests {
                 return;
             };
 
-        self.active_requests_nonce_mapping.insert(
-            new_packet.header.message_nonce.clone(),
-            node_address.clone(),
-        );
+        self.active_requests_nonce_mapping
+            .insert(new_packet.header.message_nonce, node_address.clone());
 
         match self.active_requests_mapping.entry(node_address) {
             Entry::Occupied(mut requests) => {

--- a/src/handler/active_requests.rs
+++ b/src/handler/active_requests.rs
@@ -32,6 +32,7 @@ impl ActiveRequests {
             .insert(nonce, node_address);
     }
 
+    /// Update the underlying packet for the request via message nonce.
     pub fn update_packet(&mut self, old_nonce: MessageNonce, new_packet: Packet) {
         let node_address =
             if let Some(node_address) = self.active_requests_nonce_mapping.remove(&old_nonce) {

--- a/src/handler/crypto/mod.rs
+++ b/src/handler/crypto/mod.rs
@@ -223,7 +223,7 @@ mod tests {
     use crate::packet::DefaultProtocolId;
 
     use super::*;
-    use enr::{CombinedKey, EnrBuilder, EnrKey};
+    use enr::{CombinedKey, Enr, EnrKey};
     use std::convert::TryInto;
 
     fn hex_decode(x: &'static str) -> Vec<u8> {
@@ -341,12 +341,12 @@ mod tests {
         let node1_key = CombinedKey::generate_secp256k1();
         let node2_key = CombinedKey::generate_secp256k1();
 
-        let node1_enr = EnrBuilder::new("v4")
+        let node1_enr = Enr::builder()
             .ip("127.0.0.1".parse().unwrap())
             .udp4(9000)
             .build(&node1_key)
             .unwrap();
-        let node2_enr = EnrBuilder::new("v4")
+        let node2_enr = Enr::builder()
             .ip("127.0.0.1".parse().unwrap())
             .udp4(9000)
             .build(&node2_key)

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -955,6 +955,8 @@ impl Handler {
             message_nonce
         );
         let active_requests = if let Some(nonce) = message_nonce {
+            // Except the active request that was used to establish the new session, as it has
+            // already been handled and shouldn't be replayed.
             self.active_requests
                 .remove_requests_except(node_address, &nonce)
         } else {

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -975,6 +975,8 @@ impl Handler {
                 .unwrap_or(&mut vec![])
                 .iter()
                 .filter(|req| {
+                    // Except the active request that was used to establish the new session, as it has
+                    // already been handled and shouldn't be replayed.
                     if let Some(nonce) = message_nonce.as_ref() {
                         req.packet().message_nonce() != nonce
                     } else {
@@ -997,7 +999,8 @@ impl Handler {
         };
 
         for (old_nonce, new_packet) in packets {
-            self.active_requests.update_packet(old_nonce, new_packet.clone());
+            self.active_requests
+                .update_packet(old_nonce, new_packet.clone());
             self.send(node_address.clone(), new_packet).await;
         }
     }

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -708,7 +708,11 @@ impl Handler {
                 };
 
                 // We already know the ENR. Send the handshake response packet
-                trace!("Sending Authentication response to node: {} ({:?})", node_address, request_call.id());
+                trace!(
+                    "Sending Authentication response to node: {} ({:?})",
+                    node_address,
+                    request_call.id()
+                );
                 request_call.update_packet(auth_packet.clone());
                 request_call.set_handshake_sent();
                 request_call.set_initiating_session(false);
@@ -732,7 +736,11 @@ impl Handler {
 
                 // Send the Auth response
                 let contact = request_call.contact().clone();
-                trace!("Sending Authentication response to node: {} ({:?})", node_address, request_call.id());
+                trace!(
+                    "Sending Authentication response to node: {} ({:?})",
+                    node_address,
+                    request_call.id()
+                );
                 request_call.update_packet(auth_packet.clone());
                 request_call.set_handshake_sent();
                 // Reinsert the request_call

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -961,6 +961,9 @@ impl Handler {
                 contact,
                 body
             );
+            // Remove the request from the packet filter here since the request is added in
+            // `self.send_request()` again.
+            self.remove_expected_response(contact.socket_addr());
             if let Err(request_error) = self.send_request::<P>(contact, req_id.clone(), body).await
             {
                 warn!("Failed to send next awaiting request {request_error}");

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -913,6 +913,8 @@ impl Handler {
         }
     }
 
+    /// Send all pending requests corresponding to the given node address, that were waiting for a
+    /// new session to be established or when an active outgoing challenge has expired.
     async fn send_pending_requests<P: ProtocolIdentity>(&mut self, node_address: &NodeAddress) {
         let pending_requests = self
             .pending_requests
@@ -949,9 +951,13 @@ impl Handler {
         }
     }
 
+    /// Replays all active requests for the given node address, in the case that a new session has
+    /// been established. If an optional message nonce is provided, the corresponding request will
+    /// be skipped, eg. the request that established the new session.
     async fn replay_active_requests<P: ProtocolIdentity>(
         &mut self,
         node_address: &NodeAddress,
+        // Optional message nonce to filter out the request used to establish the session.
         message_nonce: Option<MessageNonce>,
     ) {
         trace!(
@@ -1203,6 +1209,8 @@ impl Handler {
         self.active_requests.insert(node_address, request_call);
     }
 
+    /// Establishes a new session with a peer, or re-establishes an existing session if a
+    /// new challenge was issued during an ongoing session.
     async fn new_session<P: ProtocolIdentity>(
         &mut self,
         node_address: NodeAddress,

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -482,7 +482,7 @@ impl Handler {
             trace!("Request queued for node: {}", node_address);
             self.pending_requests
                 .entry(node_address)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(PendingRequest {
                     contact,
                     request_id,
@@ -967,12 +967,12 @@ impl Handler {
             message_nonce
         );
 
-        let packets = if let Some(session) = self.sessions.get_mut(&node_address) {
+        let packets = if let Some(session) = self.sessions.get_mut(node_address) {
             let mut packets = vec![];
             for request_call in self
                 .active_requests
                 .get(node_address)
-                .unwrap_or(&mut vec![])
+                .unwrap_or(&vec![])
                 .iter()
                 .filter(|req| {
                     // Except the active request that was used to establish the new session, as it has
@@ -988,7 +988,7 @@ impl Handler {
                     .encrypt_message::<P>(self.node_id, &request_call.encode())
                     .unwrap();
 
-                packets.push((request_call.packet().message_nonce().clone(), new_packet));
+                packets.push((*request_call.packet().message_nonce(), new_packet));
             }
 
             packets

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -977,10 +977,8 @@ impl Handler {
         for req in active_requests {
             let (req_id, contact, body) = req.into_request_parts();
             trace!(
-                "Active request to be replayed. {:?}, {}, {}",
-                req_id,
-                contact,
-                body
+                "Active request to be replayed. {}, {contact}, {body}",
+                RequestId::from(&req_id),
             );
             // Remove the request from the packet filter here since the request is added in
             // `self.send_request()` again.

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -694,6 +694,7 @@ impl Handler {
         // All sent requests must have an associated node_id. Therefore the following
         // must not panic.
         let node_address = request_call.contact().node_address();
+        let auth_message_nonce = auth_packet.header.message_nonce;
         match request_call.contact().enr() {
             Some(enr) => {
                 // NOTE: Here we decide if the session is outgoing or ingoing. The condition for an
@@ -749,7 +750,7 @@ impl Handler {
                 }
             }
         }
-        self.new_session::<P>(node_address, session, Some(request_nonce))
+        self.new_session::<P>(node_address, session, Some(auth_message_nonce))
             .await;
     }
 

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -925,6 +925,11 @@ impl Handler {
             .remove(node_address)
             .unwrap_or_default();
         for req in pending_requests {
+            trace!(
+                "Sending pending request {} to {node_address}. {}",
+                RequestId::from(&req.request_id),
+                req.request,
+            );
             if let Err(request_error) = self
                 .send_request::<P>(req.contact, req.request_id.clone(), req.request)
                 .await

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -1170,6 +1170,8 @@ impl Handler {
     ) {
         if let Some(current_session) = self.sessions.get_mut(&node_address) {
             current_session.update(session);
+            // If a session is re-established, due to a new handshake during an ongoing
+            // session, we need to replay any active requests from the prior session.
             self.replay_active_requests::<P>(&node_address).await;
         } else {
             self.sessions.insert(node_address, session);
@@ -1278,8 +1280,8 @@ impl Handler {
                     }
                 }
             }
+            self.remove_expected_response(node_address.socket_addr);
         }
-        self.remove_expected_response(node_address.socket_addr);
     }
 
     /// Sends a packet to the send handler to be encoded and sent.

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -1284,6 +1284,7 @@ impl Handler {
                 }
             }
         }
+        self.remove_expected_response(node_address.socket_addr);
     }
 
     /// Sends a packet to the send handler to be encoded and sent.

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -984,14 +984,16 @@ impl Handler {
                     }
                 })
             {
-                let new_packet = session
-                    .encrypt_message::<P>(self.node_id, &request_call.encode())
-                    .expect(&format!(
-                        "Failed to encrypt message for request with id: {:?}",
+                if let Ok(new_packet) =
+                    session.encrypt_message::<P>(self.node_id, &request_call.encode())
+                {
+                    packets.push((*request_call.packet().message_nonce(), new_packet));
+                } else {
+                    error!(
+                        "Failed to re-encrypt packet while replaying active request with id: {:?}",
                         request_call.id()
-                    ));
-
-                packets.push((*request_call.packet().message_nonce(), new_packet));
+                    );
+                }
             }
 
             packets

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -986,7 +986,10 @@ impl Handler {
             {
                 let new_packet = session
                     .encrypt_message::<P>(self.node_id, &request_call.encode())
-                    .unwrap();
+                    .expect(&format!(
+                        "Failed to encrypt message for request with id: {:?}",
+                        request_call.id()
+                    ));
 
                 packets.push((*request_call.packet().message_nonce(), new_packet));
             }

--- a/src/handler/request_call.rs
+++ b/src/handler/request_call.rs
@@ -119,4 +119,9 @@ impl RequestCall {
     pub fn remaining_responses_mut(&mut self) -> &mut Option<u64> {
         &mut self.remaining_responses
     }
+
+    /// Returns the id, contact, and request body for this call.
+    pub fn into_request_parts(self) -> (HandlerReqId, NodeContact, RequestBody) {
+        (self.request_id, self.contact, self.request)
+    }
 }

--- a/src/handler/request_call.rs
+++ b/src/handler/request_call.rs
@@ -119,9 +119,4 @@ impl RequestCall {
     pub fn remaining_responses_mut(&mut self) -> &mut Option<u64> {
         &mut self.remaining_responses
     }
-
-    /// Returns the id, contact, and request body for this call.
-    pub fn into_request_parts(self) -> (HandlerReqId, NodeContact, RequestBody) {
-        (self.request_id, self.contact, self.request)
-    }
 }

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -685,8 +685,8 @@ async fn remove_one_time_session() {
 #[tokio::test]
 async fn test_replay_active_requests() {
     init();
-    let sender_port = 5004;
-    let receiver_port = 5005;
+    let sender_port = 5006;
+    let receiver_port = 5007;
     let ip = "127.0.0.1".parse().unwrap();
     let key1 = CombinedKey::generate_secp256k1();
     let key2 = CombinedKey::generate_secp256k1();

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -401,34 +401,6 @@ async fn test_active_requests_remove_requests() {
 }
 
 #[tokio::test]
-async fn test_active_requests_remove_requests_except() {
-    const EXPIRY: Duration = Duration::from_secs(5);
-    let mut active_requests = ActiveRequests::new(EXPIRY);
-
-    let node_1 = create_node();
-    let node_2 = create_node();
-    let (req_1, req_1_addr) = create_req_call(&node_1);
-    let (req_2, req_2_addr) = create_req_call(&node_2);
-    let (req_3, req_3_addr) = create_req_call(&node_2);
-
-    let req_2_nonce = req_2.packet().header.message_nonce;
-    let req_3_id: RequestId = req_3.id().into();
-
-    active_requests.insert(req_1_addr, req_1);
-    active_requests.insert(req_2_addr.clone(), req_2);
-    active_requests.insert(req_3_addr, req_3);
-
-    let removed_requests = active_requests
-        .remove_requests_except(&req_2_addr, &req_2_nonce)
-        .unwrap();
-    active_requests.check_invariant();
-
-    assert_eq!(1, removed_requests.len());
-    let removed_request_id: RequestId = removed_requests.first().unwrap().id().into();
-    assert_eq!(removed_request_id, req_3_id);
-}
-
-#[tokio::test]
 async fn test_active_requests_remove_request() {
     const EXPIRY: Duration = Duration::from_secs(5);
     let mut active_requests = ActiveRequests::new(EXPIRY);

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -7,7 +7,10 @@ use crate::{
     rpc::{Request, Response},
     ConfigBuilder, IpMode,
 };
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::{
+    net::{Ipv4Addr, Ipv6Addr},
+    ops::Add,
+};
 
 use crate::{
     handler::{session::build_dummy_session, HandlerOut::RequestFailed},
@@ -592,4 +595,214 @@ async fn remove_one_time_session() {
         .remove_one_time_session(&node_address, &request_id)
         .is_some());
     assert_eq!(0, handler.one_time_sessions.len());
+}
+
+// Tests replaying active requests.
+//
+// In this test, Receiver's session expires and Receiver returns WHOAREYOU.
+// Sender then creates a new session and resend active requests.
+//
+// ```mermaid
+// sequenceDiagram
+//     participant Sender
+//     participant Receiver
+//     Note over Sender: Start discv5 server
+//     Note over Receiver: Start discv5 server
+//
+//     Note over Sender,Receiver: Session established
+//
+//     rect rgb(100, 100, 0)
+//     Note over Receiver: ** Session expired **
+//     end
+//
+//     rect rgb(10, 10, 10)
+//     Note left of Sender: Sender sends requests <br> **in parallel**.
+//     par
+//     Sender ->> Receiver: PING(id:2)
+//     and
+//     Sender -->> Receiver: PING(id:3)
+//     and
+//     Sender -->> Receiver: PING(id:4)
+//     and
+//     Sender -->> Receiver: PING(id:5)
+//     end
+//     end
+//
+//     Note over Receiver: Send WHOAREYOU<br>since the session has been expired
+//     Receiver ->> Sender: WHOAREYOU
+//
+//     rect rgb(100, 100, 0)
+//     Note over Receiver: Drop PING(id:2,3,4,5) request<br>since WHOAREYOU already sent.
+//     end
+//
+//     Note over Sender: New session established with Receiver
+//
+//     Sender ->> Receiver: Handshake message (id:2)
+//
+//     Note over Receiver: New session established with Sender
+//
+//     rect rgb(10, 10, 10)
+//     Note left of Sender: Handler::replay_active_requests()
+//     Sender ->> Receiver: PING (id:3)
+//     Sender ->> Receiver: PING (id:4)
+//     Sender ->> Receiver: PING (id:5)
+//     end
+//
+//     Receiver ->> Sender: PONG (id:2)
+//     Receiver ->> Sender: PONG (id:3)
+//     Receiver ->> Sender: PONG (id:4)
+//     Receiver ->> Sender: PONG (id:5)
+// ```
+#[tokio::test]
+async fn test_replay_active_requests() {
+    init();
+    let sender_port = 5004;
+    let receiver_port = 5005;
+    let ip = "127.0.0.1".parse().unwrap();
+    let key1 = CombinedKey::generate_secp256k1();
+    let key2 = CombinedKey::generate_secp256k1();
+
+    let sender_enr = EnrBuilder::new("v4")
+        .ip4(ip)
+        .udp4(sender_port)
+        .build(&key1)
+        .unwrap();
+
+    let receiver_enr = EnrBuilder::new("v4")
+        .ip4(ip)
+        .udp4(receiver_port)
+        .build(&key2)
+        .unwrap();
+
+    // Build sender handler
+    let (sender_exit, sender_send, mut sender_recv, mut handler) = {
+        let sender_listen_config = ListenConfig::Ipv4 {
+            ip: sender_enr.ip4().unwrap(),
+            port: sender_enr.udp4().unwrap(),
+        };
+        let sender_config = ConfigBuilder::new(sender_listen_config).build();
+        build_handler::<DefaultProtocolId>(sender_enr.clone(), key1, sender_config).await
+    };
+    let sender = async move {
+        // Start sender handler.
+        handler.start::<DefaultProtocolId>().await;
+        // After the handler has been terminated test the handler's states.
+        assert!(handler.pending_requests.is_empty());
+        assert_eq!(0, handler.active_requests.count().await);
+        assert!(handler.active_challenges.is_empty());
+        assert!(handler.filter_expected_responses.read().is_empty());
+    };
+
+    // Build receiver handler
+    // Shorten receiver's timeout to reproduce session expired.
+    let receiver_session_timeout = Duration::from_secs(1);
+    let (receiver_exit, receiver_send, mut receiver_recv, mut handler) = {
+        let receiver_listen_config = ListenConfig::Ipv4 {
+            ip: receiver_enr.ip4().unwrap(),
+            port: receiver_enr.udp4().unwrap(),
+        };
+        let receiver_config = ConfigBuilder::new(receiver_listen_config)
+            .session_timeout(receiver_session_timeout.clone())
+            .build();
+        build_handler::<DefaultProtocolId>(receiver_enr.clone(), key2, receiver_config).await
+    };
+    let receiver = async move {
+        // Start receiver handler.
+        handler.start::<DefaultProtocolId>().await;
+        // After the handler has been terminated test the handler's states.
+        assert!(handler.pending_requests.is_empty());
+        assert_eq!(0, handler.active_requests.count().await);
+        assert!(handler.active_challenges.is_empty());
+        assert!(handler.filter_expected_responses.read().is_empty());
+    };
+
+    // sender to send the first message then await for the session to be established
+    let _ = sender_send.send(HandlerIn::Request(
+        receiver_enr.clone().into(),
+        Box::new(Request {
+            id: RequestId(vec![1]),
+            body: RequestBody::Ping { enr_seq: 1 },
+        }),
+    ));
+
+    let messages_to_send = 5usize;
+
+    let sender_ops = async move {
+        let mut response_count = 0usize;
+        loop {
+            match sender_recv.recv().await {
+                Some(HandlerOut::Established(_, _, _)) => {
+                    // Sleep until receiver's session expired.
+                    tokio::time::sleep(receiver_session_timeout.add(Duration::from_millis(500)))
+                        .await;
+                    // now the session is established, send the rest of the messages
+                    for req_id in 2..=messages_to_send {
+                        let _ = sender_send.send(HandlerIn::Request(
+                            receiver_enr.clone().into(),
+                            Box::new(Request {
+                                id: RequestId(vec![req_id as u8]),
+                                body: RequestBody::Ping { enr_seq: 1 },
+                            }),
+                        ));
+                    }
+                }
+                Some(HandlerOut::Response(_, _)) => {
+                    response_count += 1;
+                    if response_count == messages_to_send {
+                        // Notify the handlers that the message exchange has been completed.
+                        sender_exit.send(()).unwrap();
+                        receiver_exit.send(()).unwrap();
+                        return;
+                    }
+                }
+                _ => continue,
+            };
+        }
+    };
+
+    let receiver_ops = async move {
+        let mut message_count = 0usize;
+        loop {
+            match receiver_recv.recv().await {
+                Some(HandlerOut::WhoAreYou(wru_ref)) => {
+                    receiver_send
+                        .send(HandlerIn::WhoAreYou(wru_ref, Some(sender_enr.clone())))
+                        .unwrap();
+                }
+                Some(HandlerOut::Request(addr, request)) => {
+                    assert!(matches!(request.body, RequestBody::Ping { .. }));
+                    let pong_response = Response {
+                        id: request.id,
+                        body: ResponseBody::Pong {
+                            enr_seq: 1,
+                            ip: ip.into(),
+                            port: sender_port,
+                        },
+                    };
+                    receiver_send
+                        .send(HandlerIn::Response(addr, Box::new(pong_response)))
+                        .unwrap();
+                    message_count += 1;
+                    if message_count == messages_to_send {
+                        return;
+                    }
+                }
+                _ => {
+                    continue;
+                }
+            }
+        }
+    };
+
+    let sleep_future = sleep(Duration::from_secs(5));
+    let message_exchange = async move {
+        let _ = tokio::join!(sender, sender_ops, receiver, receiver_ops);
+    };
+
+    tokio::select! {
+        _ = message_exchange => {}
+        _ = sleep_future => {
+            panic!("Test timed out");
+        }
+    }
 }

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -488,19 +488,19 @@ async fn test_active_requests_update_packet() {
     let (req_3, req_3_addr) = create_req_call(&node_2);
 
     let old_nonce = *req_2.packet().message_nonce();
-    active_requests.insert(req_1_addr.clone(), req_1);
+    active_requests.insert(req_1_addr, req_1);
     active_requests.insert(req_2_addr.clone(), req_2);
-    active_requests.insert(req_3_addr.clone(), req_3);
+    active_requests.insert(req_3_addr, req_3);
     active_requests.check_invariant();
 
     let new_packet = Packet::new_random(&node_2.node_id()).unwrap();
-    let new_nonce = new_packet.message_nonce().clone();
-    active_requests.update_packet(old_nonce.clone(), new_packet.clone());
+    let new_nonce = new_packet.message_nonce();
+    active_requests.update_packet(old_nonce, new_packet.clone());
     active_requests.check_invariant();
 
     assert_eq!(2, active_requests.get(&req_2_addr).unwrap().len());
     assert!(active_requests.remove_by_nonce(&old_nonce).is_none());
-    let (addr, req) = active_requests.remove_by_nonce(&new_nonce).unwrap();
+    let (addr, req) = active_requests.remove_by_nonce(new_nonce).unwrap();
     assert_eq!(addr, req_2_addr);
     assert_eq!(req.packet(), &new_packet);
 }

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -401,6 +401,34 @@ async fn test_active_requests_remove_requests() {
 }
 
 #[tokio::test]
+async fn test_active_requests_remove_requests_except() {
+    const EXPIRY: Duration = Duration::from_secs(5);
+    let mut active_requests = ActiveRequests::new(EXPIRY);
+
+    let node_1 = create_node();
+    let node_2 = create_node();
+    let (req_1, req_1_addr) = create_req_call(&node_1);
+    let (req_2, req_2_addr) = create_req_call(&node_2);
+    let (req_3, req_3_addr) = create_req_call(&node_2);
+
+    let req_2_nonce = req_2.packet().header.message_nonce.clone();
+    let req_3_id: RequestId = req_3.id().into();
+
+    active_requests.insert(req_1_addr, req_1);
+    active_requests.insert(req_2_addr.clone(), req_2);
+    active_requests.insert(req_3_addr, req_3);
+
+    let removed_requests = active_requests
+        .remove_requests_except(&req_2_addr, &req_2_nonce)
+        .unwrap();
+    active_requests.check_invariant();
+
+    assert_eq!(1, removed_requests.len());
+    let removed_request_id: RequestId = removed_requests.first().unwrap().id().into();
+    assert_eq!(removed_request_id, req_3_id);
+}
+
+#[tokio::test]
 async fn test_active_requests_remove_request() {
     const EXPIRY: Duration = Duration::from_secs(5);
     let mut active_requests = ActiveRequests::new(EXPIRY);

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -874,10 +874,6 @@ async fn test_replay_active_requests() {
 //     Receiver ->> Sender: WHOAREYOU (id:1)
 //
 //     Note over Sender: New session established with Receiver
-//     Sender ->> Receiver: Handshake message (id:1)
-//
-//
-//     Note over Receiver: New session established with Sender
 //
 //     rect rgb(0, 100, 0)
 //     Note over Sender: Send pending requests since a session has been established.
@@ -885,13 +881,17 @@ async fn test_replay_active_requests() {
 //     Sender ->> Receiver: Request (id:3)
 //     end
 //
-//     Receiver ->> Sender: Response (id:1)
+//     Sender ->> Receiver: Handshake message (id:1)
+//
+//     Note over Receiver: New session established with Sender
+//
 //     Receiver ->> Sender: Response (id:2)
 //     Receiver ->> Sender: Response (id:3)
+//     Receiver ->> Sender: Response (id:1)
 //
-//     Note over Sender: The request (id:1) completed.
 //     Note over Sender: The request (id:2) completed.
 //     Note over Sender: The request (id:3) completed.
+//     Note over Sender: The request (id:1) completed.
 // ```
 #[tokio::test]
 async fn test_send_pending_request() {

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -411,7 +411,7 @@ async fn test_active_requests_remove_requests_except() {
     let (req_2, req_2_addr) = create_req_call(&node_2);
     let (req_3, req_3_addr) = create_req_call(&node_2);
 
-    let req_2_nonce = req_2.packet().header.message_nonce.clone();
+    let req_2_nonce = req_2.packet().header.message_nonce;
     let req_3_id: RequestId = req_3.id().into();
 
     active_requests.insert(req_1_addr, req_1);
@@ -731,7 +731,7 @@ async fn test_replay_active_requests() {
             port: receiver_enr.udp4().unwrap(),
         };
         let receiver_config = ConfigBuilder::new(receiver_listen_config)
-            .session_timeout(receiver_session_timeout.clone())
+            .session_timeout(receiver_session_timeout)
             .build();
         build_handler::<DefaultProtocolId>(receiver_enr.clone(), key2, receiver_config).await
     };

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -9,9 +9,9 @@ use crate::{
 };
 use std::{
     collections::HashSet,
+    convert::TryInto,
     net::{Ipv4Addr, Ipv6Addr},
     ops::Add,
-    convert::TryInto,
 };
 
 use crate::{

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -70,7 +70,6 @@ async fn build_handler<P: ProtocolIdentity>(
         enr: Arc::new(RwLock::new(enr)),
         key: Arc::new(RwLock::new(key)),
         active_requests: ActiveRequests::new(config.request_timeout),
-        pending_requests: HashMap::new(),
         filter_expected_responses,
         sessions: LruTimeCache::new(config.session_timeout, Some(config.session_cache_capacity)),
         one_time_sessions: LruTimeCache::new(

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -11,6 +11,7 @@ use std::{
     collections::HashSet,
     convert::TryInto,
     net::{Ipv4Addr, Ipv6Addr},
+    num::NonZeroU16,
     ops::Add,
 };
 
@@ -817,7 +818,7 @@ async fn test_replay_active_requests() {
                         body: ResponseBody::Pong {
                             enr_seq: 1,
                             ip: ip.into(),
-                            port: sender_port,
+                            port: NonZeroU16::new(sender_port).unwrap(),
                         },
                     };
                     receiver_send
@@ -1011,7 +1012,7 @@ async fn test_send_pending_request() {
                         body: ResponseBody::Pong {
                             enr_seq: 1,
                             ip: ip.into(),
-                            port: sender_port,
+                            port: NonZeroU16::new(sender_port).unwrap(),
                         },
                     };
                     receiver_send

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -17,7 +17,6 @@ use crate::{
     RequestError::SelfRequest,
 };
 use active_requests::ActiveRequests;
-use enr::EnrBuilder;
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -108,12 +107,12 @@ async fn simple_session_message() {
     let key1 = CombinedKey::generate_secp256k1();
     let key2 = CombinedKey::generate_secp256k1();
 
-    let sender_enr = EnrBuilder::new("v4")
+    let sender_enr = Enr::builder()
         .ip4(ip)
         .udp4(sender_port)
         .build(&key1)
         .unwrap();
-    let receiver_enr = EnrBuilder::new("v4")
+    let receiver_enr = Enr::builder()
         .ip4(ip)
         .udp4(receiver_port)
         .build(&key2)
@@ -195,13 +194,13 @@ async fn multiple_messages() {
     let key1 = CombinedKey::generate_secp256k1();
     let key2 = CombinedKey::generate_secp256k1();
 
-    let sender_enr = EnrBuilder::new("v4")
+    let sender_enr = Enr::builder()
         .ip4(ip)
         .udp4(sender_port)
         .build(&key1)
         .unwrap();
 
-    let receiver_enr = EnrBuilder::new("v4")
+    let receiver_enr = Enr::builder()
         .ip4(ip)
         .udp4(receiver_port)
         .build(&key2)
@@ -345,11 +344,7 @@ async fn test_active_requests_insert() {
 
     let key = CombinedKey::generate_secp256k1();
 
-    let enr = EnrBuilder::new("v4")
-        .ip4(ip)
-        .udp4(port)
-        .build(&key)
-        .unwrap();
+    let enr = Enr::builder().ip4(ip).udp4(port).build(&key).unwrap();
     let node_id = enr.node_id();
 
     let contact: NodeContact = enr.into();
@@ -374,7 +369,7 @@ async fn test_self_request_ipv4() {
     init();
 
     let key = CombinedKey::generate_secp256k1();
-    let enr = EnrBuilder::new("v4")
+    let enr = Enr::builder()
         .ip4(Ipv4Addr::LOCALHOST)
         .udp4(5004)
         .build(&key)
@@ -414,7 +409,7 @@ async fn test_self_request_ipv6() {
     init();
 
     let key = CombinedKey::generate_secp256k1();
-    let enr = EnrBuilder::new("v4")
+    let enr = Enr::builder()
         .ip6(Ipv6Addr::LOCALHOST)
         .udp6(5005)
         .build(&key)
@@ -451,7 +446,7 @@ async fn test_self_request_ipv6() {
 async fn remove_one_time_session() {
     let config = ConfigBuilder::new(ListenConfig::default()).build();
     let key = CombinedKey::generate_secp256k1();
-    let enr = EnrBuilder::new("v4")
+    let enr = Enr::builder()
         .ip4(Ipv4Addr::LOCALHOST)
         .udp4(9000)
         .build(&key)
@@ -460,7 +455,7 @@ async fn remove_one_time_session() {
 
     let enr = {
         let key = CombinedKey::generate_secp256k1();
-        EnrBuilder::new("v4")
+        Enr::builder()
             .ip4(Ipv4Addr::LOCALHOST)
             .udp4(9000)
             .build(&key)

--- a/src/ipmode.rs
+++ b/src/ipmode.rs
@@ -136,7 +136,7 @@ mod tests {
 
         fn test(&self) {
             let test_enr = {
-                let builder = &mut enr::EnrBuilder::new("v4");
+                let builder = &mut enr::Enr::builder();
                 if let Some(ip4) = self.enr_ip4 {
                     builder.ip4(ip4).udp4(IP4_TEST_PORT);
                 }

--- a/src/ipmode.rs
+++ b/src/ipmode.rs
@@ -69,6 +69,17 @@ impl IpMode {
     }
 }
 
+/// Copied from the standard library. See <https://github.com/rust-lang/rust/issues/27709>
+/// The current code is behind the `ip` feature.
+pub const fn to_ipv4_mapped(ip: &std::net::Ipv6Addr) -> Option<std::net::Ipv4Addr> {
+    match ip.octets() {
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, a, b, c, d] => {
+            Some(std::net::Ipv4Addr::new(a, b, c, d))
+        }
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -228,16 +239,5 @@ mod tests {
             .ip_mode(Ip6)
             .expect_ip6(Ipv6Addr::LOCALHOST)
             .test();
-    }
-}
-
-/// Copied from the standard library. See <https://github.com/rust-lang/rust/issues/27709>
-/// The current code is behind the `ip` feature.
-pub const fn to_ipv4_mapped(ip: &std::net::Ipv6Addr) -> Option<std::net::Ipv4Addr> {
-    match ip.octets() {
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, a, b, c, d] => {
-            Some(std::net::Ipv4Addr::new(a, b, c, d))
-        }
-        _ => None,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //!
 //!    // construct a local ENR
 //!    let enr_key = CombinedKey::generate_secp256k1();
-//!    let enr = enr::EnrBuilder::new("v4").build(&enr_key).unwrap();
+//!    let enr = enr::Enr::empty(&enr_key).unwrap();
 //!
 //!    // build the tokio executor
 //!    let mut runtime = tokio::runtime::Builder::new_multi_thread()

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -493,7 +493,6 @@ impl Message {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use enr::EnrBuilder;
     use std::net::Ipv4Addr;
 
     #[test]
@@ -733,17 +732,17 @@ mod tests {
     #[test]
     fn encode_decode_nodes_response() {
         let key = CombinedKey::generate_secp256k1();
-        let enr1 = EnrBuilder::new("v4")
+        let enr1 = Enr::builder()
             .ip4("127.0.0.1".parse().unwrap())
             .udp4(500)
             .build(&key)
             .unwrap();
-        let enr2 = EnrBuilder::new("v4")
+        let enr2 = Enr::builder()
             .ip4("10.0.0.1".parse().unwrap())
             .tcp4(8080)
             .build(&key)
             .unwrap();
-        let enr3 = EnrBuilder::new("v4")
+        let enr3 = Enr::builder()
             .ip("10.4.5.6".parse().unwrap())
             .build(&key)
             .unwrap();

--- a/src/service.rs
+++ b/src/service.rs
@@ -728,10 +728,8 @@ impl Service {
 
                     // handle the case that there is more than one response
                     if total > 1 {
-                        let mut current_response = self
-                            .active_nodes_responses
-                            .remove(&id)
-                            .unwrap_or_default();
+                        let mut current_response =
+                            self.active_nodes_responses.remove(&id).unwrap_or_default();
 
                         debug!(
                             "Nodes Response: {} of {} received",

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -329,7 +329,7 @@ async fn test_handling_concurrent_responses() {
 
     // Finally, handle the second response to `Request1`.
     service.handle_rpc_response(
-        node_address.clone(),
+        node_address,
         Response {
             id: RequestId(vec![1]),
             body: ResponseBody::Nodes {

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use enr::CombinedKey;
 use parking_lot::RwLock;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, net::Ipv4Addr, sync::Arc, time::Duration};
 use tokio::sync::{mpsc, oneshot};
 
 /// Default UDP port number to use for tests requiring UDP exposure
@@ -234,7 +234,7 @@ async fn test_handling_concurrent_responses() {
     let mut service = {
         let enr_key = keypairs.pop().unwrap();
         let enr = Enr::builder()
-            .ip4("127.0.0.1".parse().unwrap())
+            .ip4(Ipv4Addr::LOCALHOST)
             .udp4(10005)
             .build(&enr_key)
             .unwrap();
@@ -247,7 +247,7 @@ async fn test_handling_concurrent_responses() {
     };
 
     let node_contact: NodeContact = Enr::builder()
-        .ip4("127.0.0.1".parse().unwrap())
+        .ip4(Ipv4Addr::LOCALHOST)
         .udp4(10006)
         .build(&keypairs.remove(0))
         .unwrap()
@@ -286,7 +286,7 @@ async fn test_handling_concurrent_responses() {
         .enumerate()
         .map(|(i, key)| {
             Enr::builder()
-                .ip4("127.0.0.1".parse().unwrap())
+                .ip4(Ipv4Addr::LOCALHOST)
                 .udp4(10007 + i as u16)
                 .build(key)
                 .unwrap()

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -235,7 +235,7 @@ async fn test_handling_concurrent_responses() {
         let enr_key = keypairs.pop().unwrap();
         let enr = EnrBuilder::new("v4")
             .ip4("127.0.0.1".parse().unwrap())
-            .udp4(10001)
+            .udp4(10005)
             .build(&enr_key)
             .unwrap();
         build_service::<DefaultProtocolId>(
@@ -248,7 +248,7 @@ async fn test_handling_concurrent_responses() {
 
     let node_contact: NodeContact = EnrBuilder::new("v4")
         .ip4("127.0.0.1".parse().unwrap())
-        .udp4(10002)
+        .udp4(10006)
         .build(&keypairs.remove(0))
         .unwrap()
         .into();
@@ -287,7 +287,7 @@ async fn test_handling_concurrent_responses() {
         .map(|(i, key)| {
             EnrBuilder::new("v4")
                 .ip4("127.0.0.1".parse().unwrap())
-                .udp4(10003 + i as u16)
+                .udp4(10007 + i as u16)
                 .build(key)
                 .unwrap()
         })

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -14,7 +14,7 @@ use crate::{
     socket::ListenConfig,
     ConfigBuilder, Enr,
 };
-use enr::{CombinedKey, EnrBuilder};
+use enr::CombinedKey;
 use parking_lot::RwLock;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::sync::{mpsc, oneshot};
@@ -106,14 +106,14 @@ async fn test_updating_connection_on_ping() {
     init();
     let enr_key1 = CombinedKey::generate_secp256k1();
     let ip = "127.0.0.1".parse().unwrap();
-    let enr = EnrBuilder::new("v4")
+    let enr = Enr::builder()
         .ip4(ip)
         .udp4(DEFAULT_UDP_PORT)
         .build(&enr_key1)
         .unwrap();
     let ip2 = "127.0.0.1".parse().unwrap();
     let enr_key2 = CombinedKey::generate_secp256k1();
-    let enr2 = EnrBuilder::new("v4")
+    let enr2 = Enr::builder()
         .ip4(ip2)
         .udp4(DEFAULT_UDP_PORT)
         .build(&enr_key2)
@@ -174,7 +174,7 @@ async fn test_connection_direction_on_inject_session_established() {
 
     let enr_key1 = CombinedKey::generate_secp256k1();
     let ip = std::net::Ipv4Addr::LOCALHOST;
-    let enr = EnrBuilder::new("v4")
+    let enr = Enr::builder()
         .ip4(ip)
         .udp4(DEFAULT_UDP_PORT)
         .build(&enr_key1)
@@ -182,7 +182,7 @@ async fn test_connection_direction_on_inject_session_established() {
 
     let enr_key2 = CombinedKey::generate_secp256k1();
     let ip2 = std::net::Ipv4Addr::LOCALHOST;
-    let enr2 = EnrBuilder::new("v4")
+    let enr2 = Enr::builder()
         .ip4(ip2)
         .udp4(DEFAULT_UDP_PORT)
         .build(&enr_key2)


### PR DESCRIPTION
## Description
In trin, we're in need of discv5 to support multiple, concurrent network requests. See #...

How was it fixed?
- Update `ActiveRequests` to support tracking multiple, concurrent, active requests for any given peer.
- Moved `HashMapDelay` to the nonce mapping rather than on the peer mapping.
- If any single request fails for a peer, all other active requests for that peer are also failed.
- Replay all active requests if a new challenge is issued.
- Added tests for `ActiveRequests` methods.

## Notes & open questions
- Updated `active_requests` methods to return a `Result` rather than an `Option`. This made sense to me to accurately reflect the cases where the mappings might be out of sync. However, I realize that the `HashMap` & `HashMapDelay` apis return an `Option`, so I don't feel strongly about this change either way.

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

## Change checklist

- [ ] Self-review
- [ ] Documentation updates if relevant
- [ ] Tests if relevant
