### PR TITLE
Add test for replay_active_requests

### DIFF
--- a/src/handler/active_requests.rs
+++ b/src/handler/active_requests.rs
@@ -87,13 +87,7 @@ impl ActiveRequests {
             .get(node_address)?
             .iter()
             .filter(|req| req.packet().message_nonce() != except)
-            .map(|req| {
-                match req.id() {
-                    HandlerReqId::Internal(id) => id,
-                    HandlerReqId::External(id) => id,
-                }
-                .clone()
-            })
+            .map(|req| req.id().into())
             .collect::<Vec<_>>();
 
         let mut requests = vec![];

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -955,6 +955,8 @@ impl Handler {
             message_nonce
         );
         let active_requests = if let Some(nonce) = message_nonce {
+            // Except the active request that was used to establish the new session, as it has
+            // already been handled and shouldn't be replayed.
             self.active_requests
                 .remove_requests_except(node_address, &nonce)
         } else {

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -708,7 +708,11 @@ impl Handler {
                 };
 
                 // We already know the ENR. Send the handshake response packet
-                trace!("Sending Authentication response to node: {} ({:?})", node_address, request_call.id());
+                trace!(
+                    "Sending Authentication response to node: {} ({:?})",
+                    node_address,
+                    request_call.id()
+                );
                 request_call.update_packet(auth_packet.clone());
                 request_call.set_handshake_sent();
                 request_call.set_initiating_session(false);
@@ -732,7 +736,11 @@ impl Handler {
 
                 // Send the Auth response
                 let contact = request_call.contact().clone();
-                trace!("Sending Authentication response to node: {} ({:?})", node_address, request_call.id());
+                trace!(
+                    "Sending Authentication response to node: {} ({:?})",
+                    node_address,
+                    request_call.id()
+                );
                 request_call.update_packet(auth_packet.clone());
                 request_call.set_handshake_sent();
                 // Reinsert the request_call

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -961,6 +961,9 @@ impl Handler {
                 contact,
                 body
             );
+            // Remove the request from the packet filter here since the request is added in
+            // `self.send_request()` again.
+            self.remove_expected_response(contact.socket_addr());
             if let Err(request_error) = self.send_request::<P>(contact, req_id.clone(), body).await
             {
                 warn!("Failed to send next awaiting request {request_error}");

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -694,6 +694,7 @@ impl Handler {
         // All sent requests must have an associated node_id. Therefore the following
         // must not panic.
         let node_address = request_call.contact().node_address();
+        let auth_message_nonce = auth_packet.header.message_nonce;
         match request_call.contact().enr() {
             Some(enr) => {
                 // NOTE: Here we decide if the session is outgoing or ingoing. The condition for an
@@ -749,7 +750,7 @@ impl Handler {
                 }
             }
         }
-        self.new_session::<P>(node_address, session, Some(request_nonce))
+        self.new_session::<P>(node_address, session, Some(auth_message_nonce))
             .await;
     }
 

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -7,7 +7,10 @@ use crate::{
     rpc::{Request, Response},
     ConfigBuilder, IpMode,
 };
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::{
+    net::{Ipv4Addr, Ipv6Addr},
+    ops::Add,
+};
 
 use crate::{
     handler::{session::build_dummy_session, HandlerOut::RequestFailed},
@@ -592,4 +595,214 @@ async fn remove_one_time_session() {
         .remove_one_time_session(&node_address, &request_id)
         .is_some());
     assert_eq!(0, handler.one_time_sessions.len());
+}
+
+// Tests replaying active requests.
+//
+// In this test, Receiver's session expires and Receiver returns WHOAREYOU.
+// Sender then creates a new session and resend active requests.
+//
+// ```mermaid
+// sequenceDiagram
+//     participant Sender
+//     participant Receiver
+//     Note over Sender: Start discv5 server
+//     Note over Receiver: Start discv5 server
+//
+//     Note over Sender,Receiver: Session established
+//
+//     rect rgb(100, 100, 0)
+//     Note over Receiver: ** Session expired **
+//     end
+//
+//     rect rgb(10, 10, 10)
+//     Note left of Sender: Sender sends requests <br> **in parallel**.
+//     par
+//     Sender ->> Receiver: PING(id:2)
+//     and
+//     Sender -->> Receiver: PING(id:3)
+//     and
+//     Sender -->> Receiver: PING(id:4)
+//     and
+//     Sender -->> Receiver: PING(id:5)
+//     end
+//     end
+//
+//     Note over Receiver: Send WHOAREYOU<br>since the session has been expired
+//     Receiver ->> Sender: WHOAREYOU
+//
+//     rect rgb(100, 100, 0)
+//     Note over Receiver: Drop PING(id:2,3,4,5) request<br>since WHOAREYOU already sent.
+//     end
+//
+//     Note over Sender: New session established with Receiver
+//
+//     Sender ->> Receiver: Handshake message (id:2)
+//
+//     Note over Receiver: New session established with Sender
+//
+//     rect rgb(10, 10, 10)
+//     Note left of Sender: Handler::replay_active_requests()
+//     Sender ->> Receiver: PING (id:3)
+//     Sender ->> Receiver: PING (id:4)
+//     Sender ->> Receiver: PING (id:5)
+//     end
+//
+//     Receiver ->> Sender: PONG (id:2)
+//     Receiver ->> Sender: PONG (id:3)
+//     Receiver ->> Sender: PONG (id:4)
+//     Receiver ->> Sender: PONG (id:5)
+// ```
+#[tokio::test]
+async fn test_replay_active_requests() {
+    init();
+    let sender_port = 5004;
+    let receiver_port = 5005;
+    let ip = "127.0.0.1".parse().unwrap();
+    let key1 = CombinedKey::generate_secp256k1();
+    let key2 = CombinedKey::generate_secp256k1();
+
+    let sender_enr = EnrBuilder::new("v4")
+        .ip4(ip)
+        .udp4(sender_port)
+        .build(&key1)
+        .unwrap();
+
+    let receiver_enr = EnrBuilder::new("v4")
+        .ip4(ip)
+        .udp4(receiver_port)
+        .build(&key2)
+        .unwrap();
+
+    // Build sender handler
+    let (sender_exit, sender_send, mut sender_recv, mut handler) = {
+        let sender_listen_config = ListenConfig::Ipv4 {
+            ip: sender_enr.ip4().unwrap(),
+            port: sender_enr.udp4().unwrap(),
+        };
+        let sender_config = ConfigBuilder::new(sender_listen_config).build();
+        build_handler::<DefaultProtocolId>(sender_enr.clone(), key1, sender_config).await
+    };
+    let sender = async move {
+        // Start sender handler.
+        handler.start::<DefaultProtocolId>().await;
+        // After the handler has been terminated test the handler's states.
+        assert!(handler.pending_requests.is_empty());
+        assert_eq!(0, handler.active_requests.count().await);
+        assert!(handler.active_challenges.is_empty());
+        assert!(handler.filter_expected_responses.read().is_empty());
+    };
+
+    // Build receiver handler
+    // Shorten receiver's timeout to reproduce session expired.
+    let receiver_session_timeout = Duration::from_secs(1);
+    let (receiver_exit, receiver_send, mut receiver_recv, mut handler) = {
+        let receiver_listen_config = ListenConfig::Ipv4 {
+            ip: receiver_enr.ip4().unwrap(),
+            port: receiver_enr.udp4().unwrap(),
+        };
+        let receiver_config = ConfigBuilder::new(receiver_listen_config)
+            .session_timeout(receiver_session_timeout.clone())
+            .build();
+        build_handler::<DefaultProtocolId>(receiver_enr.clone(), key2, receiver_config).await
+    };
+    let receiver = async move {
+        // Start receiver handler.
+        handler.start::<DefaultProtocolId>().await;
+        // After the handler has been terminated test the handler's states.
+        assert!(handler.pending_requests.is_empty());
+        assert_eq!(0, handler.active_requests.count().await);
+        assert!(handler.active_challenges.is_empty());
+        assert!(handler.filter_expected_responses.read().is_empty());
+    };
+
+    // sender to send the first message then await for the session to be established
+    let _ = sender_send.send(HandlerIn::Request(
+        receiver_enr.clone().into(),
+        Box::new(Request {
+            id: RequestId(vec![1]),
+            body: RequestBody::Ping { enr_seq: 1 },
+        }),
+    ));
+
+    let messages_to_send = 5usize;
+
+    let sender_ops = async move {
+        let mut response_count = 0usize;
+        loop {
+            match sender_recv.recv().await {
+                Some(HandlerOut::Established(_, _, _)) => {
+                    // Sleep until receiver's session expired.
+                    tokio::time::sleep(receiver_session_timeout.add(Duration::from_millis(500)))
+                        .await;
+                    // now the session is established, send the rest of the messages
+                    for req_id in 2..=messages_to_send {
+                        let _ = sender_send.send(HandlerIn::Request(
+                            receiver_enr.clone().into(),
+                            Box::new(Request {
+                                id: RequestId(vec![req_id as u8]),
+                                body: RequestBody::Ping { enr_seq: 1 },
+                            }),
+                        ));
+                    }
+                }
+                Some(HandlerOut::Response(_, _)) => {
+                    response_count += 1;
+                    if response_count == messages_to_send {
+                        // Notify the handlers that the message exchange has been completed.
+                        sender_exit.send(()).unwrap();
+                        receiver_exit.send(()).unwrap();
+                        return;
+                    }
+                }
+                _ => continue,
+            };
+        }
+    };
+
+    let receiver_ops = async move {
+        let mut message_count = 0usize;
+        loop {
+            match receiver_recv.recv().await {
+                Some(HandlerOut::WhoAreYou(wru_ref)) => {
+                    receiver_send
+                        .send(HandlerIn::WhoAreYou(wru_ref, Some(sender_enr.clone())))
+                        .unwrap();
+                }
+                Some(HandlerOut::Request(addr, request)) => {
+                    assert!(matches!(request.body, RequestBody::Ping { .. }));
+                    let pong_response = Response {
+                        id: request.id,
+                        body: ResponseBody::Pong {
+                            enr_seq: 1,
+                            ip: ip.into(),
+                            port: sender_port,
+                        },
+                    };
+                    receiver_send
+                        .send(HandlerIn::Response(addr, Box::new(pong_response)))
+                        .unwrap();
+                    message_count += 1;
+                    if message_count == messages_to_send {
+                        return;
+                    }
+                }
+                _ => {
+                    continue;
+                }
+            }
+        }
+    };
+
+    let sleep_future = sleep(Duration::from_secs(5));
+    let message_exchange = async move {
+        let _ = tokio::join!(sender, sender_ops, receiver, receiver_ops);
+    };
+
+    tokio::select! {
+        _ = message_exchange => {}
+        _ = sleep_future => {
+            panic!("Test timed out");
+        }
+    }
 }

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -401,6 +401,34 @@ async fn test_active_requests_remove_requests() {
 }
 
 #[tokio::test]
+async fn test_active_requests_remove_requests_except() {
+    const EXPIRY: Duration = Duration::from_secs(5);
+    let mut active_requests = ActiveRequests::new(EXPIRY);
+
+    let node_1 = create_node();
+    let node_2 = create_node();
+    let (req_1, req_1_addr) = create_req_call(&node_1);
+    let (req_2, req_2_addr) = create_req_call(&node_2);
+    let (req_3, req_3_addr) = create_req_call(&node_2);
+
+    let req_2_nonce = req_2.packet().header.message_nonce.clone();
+    let req_3_id: RequestId = req_3.id().into();
+
+    active_requests.insert(req_1_addr, req_1);
+    active_requests.insert(req_2_addr.clone(), req_2);
+    active_requests.insert(req_3_addr, req_3);
+
+    let removed_requests = active_requests
+        .remove_requests_except(&req_2_addr, &req_2_nonce)
+        .unwrap();
+    active_requests.check_invariant();
+
+    assert_eq!(1, removed_requests.len());
+    let removed_request_id: RequestId = removed_requests.first().unwrap().id().into();
+    assert_eq!(removed_request_id, req_3_id);
+}
+
+#[tokio::test]
 async fn test_active_requests_remove_request() {
     const EXPIRY: Duration = Duration::from_secs(5);
     let mut active_requests = ActiveRequests::new(EXPIRY);


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->

Added `test_replay_active_requests()` test. This test runs a simulation replaying active requests and verifies the handler's state.

In the simulation, nodes (Sender and Receiver) should behave as below:

```mermaid
sequenceDiagram
    participant Sender
    participant Receiver
    Note over Sender: Start discv5 server
    Note over Receiver: Start discv5 server

    Note over Sender,Receiver: Session established

    rect rgb(100, 100, 0)
    Note over Receiver: ** Session expired **
    end

    rect rgb(10, 10, 10)
    Note left of Sender: Sender sends requests <br> **in parallel**.
    par 
    Sender ->> Receiver: PING(id:2)
    and 
    Sender -->> Receiver: PING(id:3)
    and 
    Sender -->> Receiver: PING(id:4)
    and 
    Sender -->> Receiver: PING(id:5)
    end
    end

    Note over Receiver: Send WHOAREYOU<br>since the session has been expired
    Receiver ->> Sender: WHOAREYOU

    rect rgb(100, 100, 0)
    Note over Receiver: Drop PING(id:2,3,4,5) request<br>since WHOAREYOU already sent.
    end

    Note over Sender: New session established with Receiver

    Sender ->> Receiver: Handshake message (id:2)

    Note over Receiver: New session established with Sender

    rect rgb(10, 10, 10)
    Note left of Sender: Handler::replay_active_requests()
    Sender ->> Receiver: PING (id:3)
    Sender ->> Receiver: PING (id:4)
    Sender ->> Receiver: PING (id:5)
    end

    Receiver ->> Sender: PONG (id:2)
    Receiver ->> Sender: PONG (id:3)
    Receiver ->> Sender: PONG (id:4)
    Receiver ->> Sender: PONG (id:5)
```

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

## Change checklist

- [x] Self-review
- [x] Documentation updates if relevant
- [x] Tests if relevant
