### PR TITLE
Fix Service to handle concurrent NODES responses

### DIFF
--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -49,7 +49,7 @@ lazy_static! {
         RwLock::new(crate::PermitBanList::default());
 }
 
-mod test;
+pub(crate) mod test;
 
 /// Events that can be produced by the `Discv5` event stream.
 #[derive(Debug)]

--- a/src/discv5/test.rs
+++ b/src/discv5/test.rs
@@ -124,7 +124,7 @@ async fn build_nodes_from_keypairs_dual_stack(
 }
 
 /// Generate `n` deterministic keypairs from a given seed.
-fn generate_deterministic_keypair(n: usize, seed: u64) -> Vec<CombinedKey> {
+pub(crate) fn generate_deterministic_keypair(n: usize, seed: u64) -> Vec<CombinedKey> {
     let mut keypairs = Vec::new();
     for i in 0..n {
         let sk = {

--- a/src/service.rs
+++ b/src/service.rs
@@ -728,10 +728,8 @@ impl Service {
 
                     // handle the case that there is more than one response
                     if total > 1 {
-                        let mut current_response = self
-                            .active_nodes_responses
-                            .remove(&id)
-                            .unwrap_or_default();
+                        let mut current_response =
+                            self.active_nodes_responses.remove(&id).unwrap_or_default();
 
                         debug!(
                             "Nodes Response: {} of {} received",

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -3,6 +3,7 @@
 use super::*;
 
 use crate::{
+    discv5::test::generate_deterministic_keypair,
     handler::Handler,
     kbucket,
     kbucket::{BucketInsertResult, KBucketsTable, NodeStatus},
@@ -217,4 +218,123 @@ async fn test_connection_direction_on_inject_session_established() {
     let status = service.kbuckets.read().iter_ref().next().unwrap().status;
     assert!(status.is_connected());
     assert_eq!(ConnectionDirection::Outgoing, status.direction);
+}
+
+#[tokio::test]
+async fn test_handling_concurrent_responses() {
+    init();
+
+    // Seed is chosen such that all nodes are in the 256th distance of the first node.
+    let seed = 1652;
+    let mut keypairs = generate_deterministic_keypair(5, seed);
+
+    let mut service = {
+        let enr_key = keypairs.pop().unwrap();
+        let enr = EnrBuilder::new("v4")
+            .ip4("127.0.0.1".parse().unwrap())
+            .udp4(10001)
+            .build(&enr_key)
+            .unwrap();
+        build_service::<DefaultProtocolId>(
+            Arc::new(RwLock::new(enr)),
+            Arc::new(RwLock::new(enr_key)),
+            false,
+        )
+        .await
+    };
+
+    let node_contact: NodeContact = EnrBuilder::new("v4")
+        .ip4("127.0.0.1".parse().unwrap())
+        .udp4(10002)
+        .build(&keypairs.remove(0))
+        .unwrap()
+        .into();
+    let node_address = node_contact.node_address();
+
+    // Add fake requests
+    // Request1
+    service.active_requests.insert(
+        RequestId(vec![1]),
+        ActiveRequest {
+            contact: node_contact.clone(),
+            request_body: RequestBody::FindNode {
+                distances: vec![254, 255, 256],
+            },
+            query_id: Some(QueryId(1)),
+            callback: None,
+        },
+    );
+    // Request2
+    service.active_requests.insert(
+        RequestId(vec![2]),
+        ActiveRequest {
+            contact: node_contact,
+            request_body: RequestBody::FindNode {
+                distances: vec![254, 255, 256],
+            },
+            query_id: Some(QueryId(2)),
+            callback: None,
+        },
+    );
+
+    assert_eq!(3, keypairs.len());
+    let mut enrs_for_response = keypairs
+        .iter()
+        .enumerate()
+        .map(|(i, key)| {
+            EnrBuilder::new("v4")
+                .ip4("127.0.0.1".parse().unwrap())
+                .udp4(10003 + i as u16)
+                .build(key)
+                .unwrap()
+        })
+        .collect::<Vec<_>>();
+
+    // Response to `Request1` is sent as two separate messages in total. Handle the first one of the
+    // messages here.
+    service.handle_rpc_response(
+        node_address.clone(),
+        Response {
+            id: RequestId(vec![1]),
+            body: ResponseBody::Nodes {
+                total: 2,
+                nodes: vec![enrs_for_response.pop().unwrap()],
+            },
+        },
+    );
+    // Service has still two active requests since we are waiting for the second NODE response to
+    // `Request1`.
+    assert_eq!(2, service.active_requests.len());
+    // Service stores the first response to `Request1` into `active_nodes_responses`.
+    assert!(!service.active_nodes_responses.is_empty());
+
+    // Second, handle a response to *`Request2`* before the second response to `Request1`.
+    service.handle_rpc_response(
+        node_address.clone(),
+        Response {
+            id: RequestId(vec![2]),
+            body: ResponseBody::Nodes {
+                total: 1,
+                nodes: vec![enrs_for_response.pop().unwrap()],
+            },
+        },
+    );
+    // `Request2` is completed so now the number of active requests should be one.
+    assert_eq!(1, service.active_requests.len());
+    // Service still keeps the first response in `active_nodes_responses`.
+    assert!(!service.active_nodes_responses.is_empty());
+
+    // Finally, handle the second response to `Request1`.
+    service.handle_rpc_response(
+        node_address.clone(),
+        Response {
+            id: RequestId(vec![1]),
+            body: ResponseBody::Nodes {
+                total: 2,
+                nodes: vec![enrs_for_response.pop().unwrap()],
+            },
+        },
+    );
+    assert!(service.active_requests.is_empty());
+    assert!(service.active_nodes_responses.is_empty());
 }

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -174,7 +174,7 @@ async fn test_connection_direction_on_inject_session_established() {
     let ip = std::net::Ipv4Addr::LOCALHOST;
     let enr = EnrBuilder::new("v4")
         .ip4(ip)
-        .udp4(10001)
+        .udp4(10003)
         .build(&enr_key1)
         .unwrap();
 
@@ -182,7 +182,7 @@ async fn test_connection_direction_on_inject_session_established() {
     let ip2 = std::net::Ipv4Addr::LOCALHOST;
     let enr2 = EnrBuilder::new("v4")
         .ip4(ip2)
-        .udp4(10002)
+        .udp4(10004)
         .build(&enr_key2)
         .unwrap();
 
@@ -232,7 +232,7 @@ async fn test_handling_concurrent_responses() {
         let enr_key = keypairs.pop().unwrap();
         let enr = EnrBuilder::new("v4")
             .ip4("127.0.0.1".parse().unwrap())
-            .udp4(10001)
+            .udp4(10005)
             .build(&enr_key)
             .unwrap();
         build_service::<DefaultProtocolId>(
@@ -245,7 +245,7 @@ async fn test_handling_concurrent_responses() {
 
     let node_contact: NodeContact = EnrBuilder::new("v4")
         .ip4("127.0.0.1".parse().unwrap())
-        .udp4(10002)
+        .udp4(10006)
         .build(&keypairs.remove(0))
         .unwrap()
         .into();
@@ -284,7 +284,7 @@ async fn test_handling_concurrent_responses() {
         .map(|(i, key)| {
             EnrBuilder::new("v4")
                 .ip4("127.0.0.1".parse().unwrap())
-                .udp4(10003 + i as u16)
+                .udp4(10007 + i as u16)
                 .build(key)
                 .unwrap()
         })

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -326,7 +326,7 @@ async fn test_handling_concurrent_responses() {
 
     // Finally, handle the second response to `Request1`.
     service.handle_rpc_response(
-        node_address.clone(),
+        node_address,
         Response {
             id: RequestId(vec![1]),
             body: ResponseBody::Nodes {


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->

This PR fixes a bug I reported [here](https://github.com/sigp/discv5/pull/200#issuecomment-1732134151). I have changed the key type of `active_nodes_responses` from `NodeId` to `RequestId` to handle concurrent NODES responses.



## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

## Change checklist

- [x] Self-review
- [x] Documentation updates if relevant
- [x] Tests if relevant
